### PR TITLE
28 compatibility python 313 and 314

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest" ] #, "macos-latest", "windows-latest"]
-        python-version: ["3.11"] # fix tests to support older versions
+        python-version: ["3.12"] # fix tests to support older versions
 
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
       # build environment with pip
       - name: Install ffpiv
         run: |
-          
+
           pip install --upgrade pip
           pip install .[test,extra]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,15 @@ jobs:
       - name: Cache hit
         run: echo '${{ steps.pysetup.outputs.cache-hit }}'
 
+      - name: FFTW dependencies
+        run: |
+          sudo apt update
+          sudo apt install libfftw3-dev -y
+
       # build environment with pip
       - name: Install ffpiv
         run: |
+          
           pip install --upgrade pip
           pip install .[test,extra]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
+## [0.2.0] - 2025-12-22
+### Added
+- New engine `engine="fftw"` for FFT-based processing. This engine is faster than the default engine `engine="numpy"`
+  It is slower than the default `engine="numba"`. This engine is added for extending FF-PIV to other platforms.
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+
 ## [0.1.4] - 2025-09-19
 ### Added
 ### Changed
-- A new flag `clip_norm` is added to `api.piv`, `api.piv_stack` and all downstream functions to allow a user to decide 
+- A new flag `clip_norm` is added to `api.piv`, `api.piv_stack` and all downstream functions to allow a user to decide
   if intensities of interrogation windows should be clipped between 0 and the maximum value of the interrogation window.
   If preprocessing is applied by external functions, the user should typically not clip the intensities.
   `clip_norm=True` makes all results consistent with the original behaviour and with OpenPIV.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ To install FF-PIV, ensure you have python>=3.9. You can use `pip` for installati
 pip install ffpiv
 ```
 
+> [!NOTE]
+> If you are on python 3.13 or higher, the dependency `rocket-fft` needs to be installed manually from a separate
+> fork of the original code. This is because the original package on PyPi is not yet upgraded. Please use:
+>
+> ```sh
+> pip install git+https://github.com/localdevices/rocket-fft.git
+> ```
+> without this, the code will run, but will fall back to the slightly slower `pyFFTW` library. A warning will be
+> printed to the console when you use `engine="numba"`. `pyFFTW` is still much faster than `numpy`.
+
 ## Usage Examples
 
 If you want to work with the examples, ensure to install the extra dependencies first as follows:

--- a/ffpiv/__init__.py
+++ b/ffpiv/__init__.py
@@ -2,5 +2,13 @@
 
 __version__ = "0.1.4"
 
-from . import pnb, pnp, sample_data, window
+from . import pnp, sample_data, window
+
+try:
+    import rocket_fft  # noqa: F401
+    from . import pnb
+    HAS_ROCKET_FFT = True
+except ImportError:
+    HAS_ROCKET_FFT = False
+
 from .api import *

--- a/ffpiv/__init__.py
+++ b/ffpiv/__init__.py
@@ -1,16 +1,18 @@
 """FF-PIV: Fast and Flexible Particle Image Velocimetry analysis powered by numba."""
 
-__version__ = "0.1.4"
+__version__ = "0.2.0"
 
-import os
-import platformdirs
 from pathlib import Path
+
+import platformdirs
 
 from . import pnp, sample_data, window
 
 try:
     import rocket_fft  # noqa: F401
+
     from . import pnb
+
     HAS_ROCKET_FFT = True
 except ImportError:
     HAS_ROCKET_FFT = False
@@ -19,7 +21,7 @@ cache_dir = Path(platformdirs.user_cache_dir("ffpiv"))
 if not cache_dir.exists():
     cache_dir.mkdir(parents=True)
 
-_WISDOM_FILE =  cache_dir / ".ffpiv_wisdom.pkl"
+_WISDOM_FILE = cache_dir / ".ffpiv_wisdom.pkl"
 
 # import user top functionality
 from .api import *

--- a/ffpiv/__init__.py
+++ b/ffpiv/__init__.py
@@ -2,6 +2,10 @@
 
 __version__ = "0.1.4"
 
+import os
+import platformdirs
+from pathlib import Path
+
 from . import pnp, sample_data, window
 
 try:
@@ -11,4 +15,11 @@ try:
 except ImportError:
     HAS_ROCKET_FFT = False
 
+cache_dir = Path(platformdirs.user_cache_dir("ffpiv"))
+if not cache_dir.exists():
+    cache_dir.mkdir(parents=True)
+
+_WISDOM_FILE =  cache_dir / ".ffpiv_wisdom.pkl"
+
+# import user top functionality
 from .api import *

--- a/ffpiv/api.py
+++ b/ffpiv/api.py
@@ -7,9 +7,11 @@ from typing import Literal, Optional, Tuple
 
 import numpy as np
 
-import ffpiv.pnb as pnb
+from ffpiv import window, HAS_ROCKET_FFT
+if HAS_ROCKET_FFT:
+    import ffpiv.pnb as pnb
+import ffpiv.pfftw as pfftw
 import ffpiv.pnp as pnp
-from ffpiv import window
 
 
 def subwindows(

--- a/ffpiv/api.py
+++ b/ffpiv/api.py
@@ -8,10 +8,25 @@ from typing import Literal, Optional, Tuple
 import numpy as np
 
 from ffpiv import window, HAS_ROCKET_FFT
+
 if HAS_ROCKET_FFT:
     import ffpiv.pnb as pnb
 import ffpiv.pfftw as pfftw
 import ffpiv.pnp as pnp
+
+def check_engine(engine: Literal["fftw", "numba", "numpy"] = "fftw"):
+    """Check if the requested engine is available.
+
+    If not, an alternative will be attempted to be selected and returned
+    """
+    if engine == "numba" and not HAS_ROCKET_FFT:
+        warnings.warn('You selected "numba" but rocket_fft is not installed, switching to "fftw"', stacklevel=2)
+    if engine == "numba" and HAS_ROCKET_FFT:
+        return engine
+    if engine == "fftw" or engine == "numpy":
+        return engine
+    else:
+        return "fftw"
 
 
 def subwindows(
@@ -79,7 +94,7 @@ def piv(
     img_b: np.ndarray,
     window_size: Tuple[int, int] = (64, 64),
     overlap: Tuple[int, int] = (0, 0),
-    engine: Literal["numba", "numpy"] = "numba",
+    engine: Literal["numba", "numpy", "fftw"] = "fftw",
     clip_norm: bool = False,
 ):
     """Perform particle image velocimetry on a pair of images.
@@ -94,8 +109,9 @@ def piv(
         Interrogation window size in y (first) and x (second) dimension.
     overlap : tuple[int, int], optional
         Overlap on window sizes in y (first) and x( second) dimension.
-    engine : Literal["numba", "numpy"], optional
-        Compute correlations and displacements with "numba" (default) or "numpy"
+    engine : Literal["fftw", "numba", "numpy"], optional
+        Compute correlations and displacements with "fftw" (default) or "numpy" or "numba"
+        "numba" only works for python <= 3.12 as it depends on rocket_fft, which is unsupported on later versions.
     clip_norm : bool, optional
         If set to True, the normalized intensities is clipped to the range [0, max] where max is the maximum of the
         window, before FFT is performed.
@@ -109,6 +125,7 @@ def piv(
         Y-direction velocimetry results in pixel displacements.
 
     """
+    engine = check_engine(engine)
     # get subwindows
     imgs = np.stack((img_a, img_b), axis=0).astype(np.float64)
     # get correlations and row/column layout
@@ -123,7 +140,7 @@ def piv_stack(
     imgs: np.ndarray,
     window_size: Tuple[int, int] = (64, 64),
     overlap: Tuple[int, int] = (0, 0),
-    engine: Literal["numba", "numpy"] = "numba",
+    engine: Literal["fftw", "numba", "numpy"] = "fftw",
     clip_norm: bool = False,
 ):
     """Perform particle image velocimetry over a stack of images.
@@ -136,8 +153,9 @@ def piv_stack(
         Interrogation window size in y (first) and x (second) dimension
     overlap : tuple[int, int], optional
         Overlap on window sizes in y (first) and x( second) dimension
-    engine : Literal["numba", "numpy"], optional
-        Compute correlations and displacements with "numba" (default) or "numpy"
+    engine : Literal["fftw", "numba", "numpy"], optional
+        Compute correlations and displacements with "fftw" (default) or "numpy" or "numba"
+        "numba" only works for python <= 3.12 as it depends on rocket_fft, which is unsupported on later versions.
     clip_norm : bool, optional
         If set to True, the normalized intensities is clipped to the range [0, max] where max is the maximum of the
         window, before FFT is performed.
@@ -152,13 +170,16 @@ def piv_stack(
 
     """
     # get correlations and row/column layout
+    t0 = time.time()
     x, y, corr = cross_corr(imgs, window_size=window_size, overlap=overlap, engine=engine, clip_norm=clip_norm)
+    t1 = time.time()
     # get displacements
     n_rows, n_cols = len(y), len(x)
+    print(f"UV displacements calculating after {t1 -t0} s.")
     if engine == "numpy":
         u, v = pnp.multi_u_v_displacement(corr, n_rows, n_cols)
     else:
-        u, v = pnb.multi_u_v_displacement(corr, n_rows, n_cols)
+        u, v = pnp.multi_u_v_displacement(corr, n_rows, n_cols)
     return u, v
 
 
@@ -167,7 +188,7 @@ def cross_corr(
     window_size: Tuple[int, int] = (64, 64),
     overlap: Tuple[int, int] = (32, 32),
     search_area_size: Optional[Tuple[int, int]] = None,
-    engine: Literal["numba", "numpy"] = "numba",
+    engine: Literal["fftw", "numba", "numpy"] = "fftw",
     normalize: bool = False,
     clip_norm: bool = False,
     verbose: bool = True,
@@ -185,14 +206,14 @@ def cross_corr(
     search_area_size : tuple[int, int], optional
         size of the search area. This is used in the second frame window set, to explore areas larger than
         `window_size`.
-    engine : Literal["numba", "numpy"], optional
-        The engine to use for calculation, by default "numba".
+    engine : Literal["fftw", "numba", "numpy"], optional
+        The engine to use for calculation, by default "fftw".
+        "numba" only works for python <= 3.12 as it depends on rocket_fft, which is unsupported on later versions.
     normalize : bool, optional
         if set, each window will be normalized with spatial mean and standard deviation, and numbers capped to 0.
     clip_norm : bool, optional
         If set to True, the normalized intensities is clipped to the range [0, max] where max is the maximum of the
         window, before FFT is performed.
-
     verbose : bool, optional
         if set (default), warnings will be displayed if the amount of available memory is low.
 
@@ -206,6 +227,7 @@ def cross_corr(
         A 4D array containing per image and per interrogation window the correlation results.
 
     """
+    engine = check_engine(engine)
     # check if masking is needed
     window_size = window.round_to_even(window_size)
     if search_area_size is None:
@@ -258,6 +280,8 @@ def cross_corr(
     idx = np.any(window_stack[0] != 0, axis=(-1, -2))
     if engine == "numpy":
         corr = pnp.multi_img_ncc(window_stack, mask=mask, idx=idx, clip_norm=clip_norm)
+    elif engine == "fftw":
+        corr = pfftw.multi_img_ncc(window_stack, mask=mask, idx=idx, clip_norm=clip_norm)
     else:
         corr = pnb.multi_img_ncc(window_stack, mask=mask, idx=idx, clip_norm=clip_norm)
     # memory cleanup
@@ -266,7 +290,7 @@ def cross_corr(
     return x, y, corr
 
 
-def u_v_displacement(corr: np.array, n_rows: int, n_cols: int, engine: Literal["numba", "numpy"] = "numba"):
+def u_v_displacement(corr: np.array, n_rows: int, n_cols: int, engine: Literal["fftw", "numba", "numpy"] = "fftw"):
     """Compute x-direction and y-directional displacements.
 
     Parameters
@@ -277,8 +301,9 @@ def u_v_displacement(corr: np.array, n_rows: int, n_cols: int, engine: Literal["
         The number of rows in the output displacement arrays.
     n_cols : int
         The number of columns in the output displacement arrays.
-    engine : Literal["numba", "numpy"], optional
-        The computational engine to use for calculating displacements, either "numba" or "numpy". Default is "numba".
+    engine : Literal["fftw", "numba", "numpy"], optional
+        The computational engine to use for calculating displacements, "fftw", "numba" or "numpy". Default is "fftw".
+        "numba" only works for python <= 3.12 as it depends on rocket_fft, which is unsupported on later versions.
 
     Returns
     -------
@@ -288,8 +313,10 @@ def u_v_displacement(corr: np.array, n_rows: int, n_cols: int, engine: Literal["
         An array containing the v-component of the displacements.
 
     """
+    engine = check_engine(engine)
     if engine == "numpy":
         u, v = pnp.multi_u_v_displacement(corr, n_rows, n_cols)
     else:
-        u, v = pnb.multi_u_v_displacement(corr, n_rows, n_cols)
+        # from ffpiv.pnb import multi_u_v_displacement
+        u, v = pnp.multi_u_v_displacement(corr, n_rows, n_cols)
     return u, v

--- a/ffpiv/nb_utils.py
+++ b/ffpiv/nb_utils.py
@@ -1,0 +1,76 @@
+import numba as nb
+import numpy as np
+
+
+@nb.jit(parallel=True, cache=True, nopython=True)
+def u_v_displacement(
+    corr,
+    n_rows,
+    n_cols,
+):
+    """Compute u (x-direction) and v (y-direction) displacements.
+
+    u and v displacements are computed from correlations in windows and number and rows / columns using numba
+    back-end.
+
+    Parameters
+    ----------
+    corr : np.ndarray
+        (w, y, x) correlation planes for each interrogation window (w).
+    n_rows : int
+        number of rows in the correlation map.
+    n_cols : int
+        number of columns in the correlation map.
+
+    Returns
+    -------
+    u : np.ndarray
+        (n_rows, n_cols) array of x-direction velocimetry results in pixel displacements.
+    v : np.ndarray
+        (n_rows, n_cols) array of y-direction velocimetry results in pixel displacements.
+
+    """
+    u = np.zeros((n_rows, n_cols))
+    v = np.zeros((n_rows, n_cols))
+
+    # center point of the correlation map
+    default_peak_position = np.floor(np.array(corr[0, :, :].shape) / 2)
+    for k in nb.prange(n_rows):
+        for m in nb.prange(n_cols):
+            peak = (
+                peak_position(
+                    corr[k * n_cols + m],
+                )
+                - default_peak_position
+            )
+            u[k, m] = peak[1]
+            v[k, m] = peak[0]
+    return u, v
+
+
+@nb.jit(cache=True, nopython=True)
+def peak_position(corr):
+    """Compute peak positions for correlations in each interrogation window using numba back-end."""
+    eps = 1e-7
+    idx = np.argmax(corr)
+    peak1_i, peak1_j = idx // len(corr), idx % len(corr)
+    # check if valid
+    valid = peak1_i != 0 and peak1_i != corr.shape[-2] - 1 and peak1_j != 0 and peak1_j != corr.shape[-1] - 1
+    if valid:
+        corr = corr + eps  # prevents log(0) = nan if "gaussian" is used (notebook)
+        c = corr[peak1_i, peak1_j] + eps
+        cl = corr[peak1_i - 1, peak1_j] + eps
+        cr = corr[peak1_i + 1, peak1_j] + eps
+        cd = corr[peak1_i, peak1_j - 1] + eps
+        cu = corr[peak1_i, peak1_j + 1] + eps
+
+        # gaussian peak
+        nom1 = np.log(cl) - np.log(cr)
+        den1 = 2 * np.log(cl) - 4 * np.log(c) + 2 * np.log(cr) + eps
+        nom2 = np.log(cd) - np.log(cu)
+        den2 = 2 * np.log(cd) - 4 * np.log(c) + 2 * np.log(cu) + eps
+
+        subp_peak_position = np.array([peak1_i + nom1 / den1, peak1_j + nom2 / den2])
+    else:
+        subp_peak_position = np.array([np.nan, np.nan])
+    return subp_peak_position

--- a/ffpiv/pfftw.py
+++ b/ffpiv/pfftw.py
@@ -1,0 +1,311 @@
+"""pyFFTW cross-correlation related functions."""
+
+import numpy as np
+import pyfftw
+
+# Enable FFTW caching for repeated transforms of the same size
+pyfftw.interfaces.cache.enable()
+
+
+def normalize_intensity(img: np.uint8, clip_norm: bool = False) -> np.float64:
+    """Normalize intensity of an image interrogation window using pyFFTW back-end.
+
+    Parameters
+    ----------
+    img : np.ndarray (w * y * x)
+        Image subdivided into interrogation windows (w)
+    clip_norm : bool, optional
+        If set to True, the normalized intensities are clipped to the range [0, max].
+
+    Returns
+    -------
+    np.ndarray
+        [w * y * z] array with normalized intensities per window
+
+    """
+    img = img.astype(np.float32)
+    img_mean = img.mean(axis=(-2, -1), keepdims=True)
+    img = img - img_mean
+    img_std = img.std(axis=(-2, -1), keepdims=True)
+    img = np.divide(img, img_std, out=np.zeros_like(img), where=(img_std != 0))
+    if clip_norm:
+        return np.clip(img, 0, img.max())
+    else:
+        return img
+
+
+def rfft2(x):
+    """Compute 2D real FFT using pyFFTW.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        Input array.
+
+    Returns
+    -------
+    np.ndarray
+        Complex array containing the FFT result.
+
+    """
+    return pyfftw.interfaces.numpy_fft.rfft2(x, threads=-1)
+
+
+def irfft2(x, s=None):
+    """Compute 2D inverse real FFT using pyFFTW.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        Input complex array.
+    s : tuple, optional
+        Shape of the output (optional).
+
+    Returns
+    -------
+    np.ndarray
+        Real array containing the inverse FFT result.
+
+    """
+    return pyfftw.interfaces.numpy_fft.irfft2(x, s=s, threads=-1)
+
+
+def fftshift(x, axes=None):
+    """Shift the zero-frequency component to the center.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        Input array.
+    axes : int or tuple of ints, optional
+        Axes over which to shift.
+
+    Returns
+    -------
+    np.ndarray
+        Shifted array.
+
+    """
+    return np.fft.fftshift(x, axes=axes)
+
+
+def ncc(image_a, image_b, clip_norm=False):
+    """Perform normalized cross-correlation on a set of interrogation window pairs with pyFFTW back-end.
+
+    Parameters
+    ----------
+    image_a : np.ndarray
+        uint8 type array [w, y, x] containing a single image, sliced into interrogation windows (w)
+    image_b : np.ndarray
+        uint8 type array [w, y, x] containing the next image, sliced into interrogation windows (w)
+    clip_norm : bool, optional
+        If set to True, the normalized intensities are clipped to the range [0, max] where max is the maximum of the
+        window, before FFT is performed.
+
+    Returns
+    -------
+    np.ndarray
+        float64 [w * y * x] correlations of interrogation window pixels
+
+    """
+    const = np.multiply(*image_a.shape[-2:])
+    image_a = normalize_intensity(image_a, clip_norm)
+    image_b = normalize_intensity(image_b, clip_norm)
+    f2a = np.conj(rfft2(image_a))
+    f2b = rfft2(image_b)
+    return np.clip(fftshift(irfft2(f2a * f2b).real, axes=(-2, -1)) / const, 0, 1)
+
+
+def multi_img_ncc(imgs, mask=None, idx=None, clip_norm=False):
+    """Compute correlation over all image pairs in `imgs` using pyFFTW back-end.
+
+    Correlations are computed for each interrogation window (dim1) and each image pair (dim0)
+    Because pair-wise correlation is performed the resulting dim0 size one stride smaller than the input imgs array.
+
+    Parameters
+    ----------
+    imgs : np.ndarray
+        [i, w, y, x] set of images (i), subdivided into windows (w) for cross-correlation computation.
+    mask : np.ndarray
+        [y, x] array containing ones in the area covered by a window, and zeros in the search area around the window.
+    idx : np.ndarray, optional
+        contains which windows (dimension w in imgs) should be cross correlated. If not provided, all windows are
+        treated.
+    clip_norm : bool, optional
+        If set to True, the normalized intensities are clipped to the range [0, max] where max is the maximum of the
+        window, before FFT is performed.
+
+    Returns
+    -------
+    np.ndarray
+        float64 [(i - 1), w, y, x] correlations of interrogation window pixels for each image pair spanning i.
+
+    """
+    corr = np.empty((len(imgs) - 1, imgs.shape[-3], imgs.shape[-2], imgs.shape[-1]), dtype=np.float32)
+    corr.fill(np.nan)
+    if idx is None:
+        idx = np.repeat(True, imgs.shape[-3])
+    for n in range(len(imgs) - 1):
+        img_a = imgs[n, idx] * mask[idx]
+        img_b = imgs[n + 1, idx]
+        res = ncc(img_a, img_b, clip_norm)
+        corr[n, idx] = res.astype(np.float32)
+    return corr
+
+
+def peak_position(corr):
+    """Compute peak positions for correlations in each interrogation window using pyFFTW back-end.
+
+    Parameters
+    ----------
+    corr : np.ndarray
+        A 3D array of shape (w, y, x) representing the correlation maps for which the peak positions are to be
+        identified.
+
+    Returns
+    -------
+    subp_peak_position : np.ndarray
+        A 2D array of shape (w, 2) where each row corresponds to the subpixel peak positions (i, j) for each 2D slice
+        in the input correlation maps.
+
+    """
+    eps = 1e-7
+    # pre-define sub peak position array
+    subp_peak_position = np.zeros((len(corr), 2)) * np.nan
+    # Find argmax along axis (1, 2) for each 2D slice of the input
+    idx = np.argmax(corr.reshape(corr.shape[0], -1), axis=1)
+    peak1_i = idx // corr.shape[1]
+    peak1_j = idx % corr.shape[2]
+
+    # Adding eps to avoid log(0)
+    corr = corr + eps
+    valid_idx = np.where(
+        np.all(
+            np.array([peak1_i != 0, peak1_i != corr.shape[-2] - 1, peak1_j != 0, peak1_j != corr.shape[-1] - 1]), axis=0
+        )
+    )
+    peak1_i = peak1_i[valid_idx]
+    peak1_j = peak1_j[valid_idx]
+
+    # Indexing the peak and neighboring points for vectorized operations
+    c = corr[valid_idx, peak1_i, peak1_j] + eps
+    cl = corr[valid_idx, peak1_i - 1, peak1_j] + eps
+    cr = corr[valid_idx, peak1_i + 1, peak1_j] + eps
+    cd = corr[valid_idx, peak1_i, peak1_j - 1] + eps
+    cu = corr[valid_idx, peak1_i, peak1_j + 1] + eps
+
+    # Gaussian peak calculations (nom1, den1, nom2, den2)
+    nom1 = np.log(cl) - np.log(cr)
+    den1 = 2 * np.log(cl) - 4 * np.log(c) + 2 * np.log(cr) + eps
+    nom2 = np.log(cd) - np.log(cu)
+    den2 = 2 * np.log(cd) - 4 * np.log(c) + 2 * np.log(cu) + eps
+
+    # Subpixel peak position
+    subp_peak_position[valid_idx] = np.vstack([peak1_i + nom1 / den1, peak1_j + nom2 / den2]).T
+
+    return subp_peak_position
+
+
+def u_v_displacement(corr: np.ndarray, n_rows: int, n_cols: int):
+    """Compute u (x-direction) and v (y-direction) displacements from correlations using pyFFTW back end.
+
+    Results are organized following the row and column organization provided by `n_rows` and `n_cols`.
+
+    Parameters
+    ----------
+    corr : np.ndarray
+        A 3D array of shape [w, y, x] containing the correlation maps.
+    n_rows : int
+        Number of rows in the image interrogation windows.
+    n_cols : int
+        Number of columns in the image interrogation windows.
+
+    Returns
+    -------
+    u : np.ndarray
+        2D array containing x-direction displacements for each image pair and window.
+    v : np.ndarray
+        2D array containing y-direction displacements for each image pair and window.
+
+    """
+    peaks = peak_position(corr.astype(np.float64))
+    peaks_def = np.floor(np.array(corr[0, :, :].shape) / 2)
+    u = peaks[:, 1].reshape(n_rows, n_cols) - peaks_def[1]
+    v = peaks[:, 0].reshape(n_rows, n_cols) - peaks_def[0]
+    return u, v
+
+
+def multi_u_v_displacement(corr: np.ndarray, n_rows: int, n_cols: int):
+    """Compute u (x-direction) and v (y-direction) displacements for multiple correlation windows using pyFFTW back-end.
+
+    Parameters
+    ----------
+    corr : np.ndarray
+        A 4D array of shape [(i - 1), w, y, x] containing the correlation maps.
+    n_rows : int
+        Number of rows in the image interrogation windows.
+    n_cols : int
+        Number of columns in the image interrogation windows.
+
+    Returns
+    -------
+    u : np.ndarray
+        3D array containing x-direction displacements for each image pair and window.
+    v : np.ndarray
+        3D array containing y-direction displacements for each image pair and window.
+
+    """
+    u = np.empty((corr.shape[0], n_rows, n_cols))
+    v = np.empty((corr.shape[0], n_rows, n_cols))
+    for i in range(corr.shape[0]):
+        u[i], v[i] = u_v_displacement(corr[i], n_rows, n_cols)
+    return u, v
+
+
+
+def signal_to_noise(corr: np.ndarray) -> np.ndarray:
+    """Compute signal-to-noise ratio per interrogation window using pyFFTW back-end.
+
+    This is computed by dividing the peak of the correlation field by the mean.
+
+    Parameters
+    ----------
+    corr : np.ndarray
+        (w, y, x) correlations for each interrogation window (w).
+
+    Returns
+    -------
+    np.ndarray
+        vector with signal to noise ratios for each window.
+
+    """
+    s2n = np.empty(len(corr), dtype=np.float64)
+    for n in range(len(corr)):
+        _c = corr[n]
+        _c_max = _c.max()
+        if _c_max < 1e-3:
+            # no correlation
+            s2n[n] = 0.0
+        else:
+            s2n[n] = _c_max / abs(_c.mean())
+    return s2n
+
+
+def multi_signal_to_noise(corr: np.ndarray) -> np.ndarray:
+    """Compute signal to noise for multiple images at once using pyFFTW back-end.
+
+    Parameters
+    ----------
+    corr : np.ndarray
+        (i, w, y, x) correlations for each interrogation window (w) in each image pair (i).
+
+    Returns
+    -------
+    np.ndarray
+        (i, w) array with signal to noise ratios for each window and image pair.
+
+    """
+    s2n = np.zeros(corr.shape[0:2])
+    for i in range(len(corr)):
+        s2n[i] = signal_to_noise(corr[i])
+    return s2n

--- a/ffpiv/pfftw.py
+++ b/ffpiv/pfftw.py
@@ -1,37 +1,122 @@
 """pyFFTW cross-correlation related functions."""
-
+import atexit
+import multiprocessing
 import numpy as np
+import numba as nb
+import os
+import pickle
 import pyfftw
 
-# Enable FFTW caching for repeated transforms of the same size
+from ffpiv import _WISDOM_FILE
+from functools import lru_cache
+
+# # # Enable FFTW caching for repeated transforms of the same size
+# pyfftw.interfaces.cache.enable()
+
+
+# Configure pyFFTW for optimal performance
 pyfftw.interfaces.cache.enable()
+# pyfftw.interfaces.cache.set_keepalive_time(30.0)  # Keep plans alive for 30 seconds
+pyfftw.config.NUM_THREADS = multiprocessing.cpu_count()
+pyfftw.config.PLANNER_EFFORT = 'FFTW_MEASURE'
+
+def _load_wisdom():
+    """Load FFTW wisdom from file if available."""
+    if os.path.exists(_WISDOM_FILE):
+        try:
+            with open(_WISDOM_FILE, "rb") as f:
+                wisdom = pickle.load(f)
+            pyfftw.import_wisdom(wisdom)
+            print("Loaded FFTW wisdom from file.")
+        except Exception:
+            pass  # Silently ignore if we can't load wisdom
 
 
-def normalize_intensity(img: np.uint8, clip_norm: bool = False) -> np.float64:
-    """Normalize intensity of an image interrogation window using pyFFTW back-end.
+def _save_wisdom():
+    """Save FFTW wisdom to file for future sessions."""
+    try:
+        wisdom = pyfftw.export_wisdom()
+        with open(_WISDOM_FILE, "wb") as f:
+            pickle.dump(wisdom, f)
+        print("Saved FFTW wisdom to file.")
+    except Exception:
+        pass  # Silently ignore if we can't save wisdom
+
+_load_wisdom()
+
+# Register save_wisdom to run at interpreter exit
+atexit.register(_save_wisdom)
+
+
+@nb.jit(nb.float32[:, :, :](nb.float32[:, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
+def normalize_intensity(img: np.ndarray) -> np.ndarray:
+    """Normalize intensity of an image interrogation window using numba back-end.
 
     Parameters
     ----------
-    img : np.ndarray (w * y * x)
-        Image subdivided into interrogation windows (w)
-    clip_norm : bool, optional
-        If set to True, the normalized intensities are clipped to the range [0, max].
+    img : np.ndarray (y, x)
+        Image window
 
     Returns
     -------
     np.ndarray
-        [w * y * z] array with normalized intensities per window
+        (y, x) array with normalized intensities of window
 
     """
-    img = img.astype(np.float32)
-    img_mean = img.mean(axis=(-2, -1), keepdims=True)
-    img = img - img_mean
-    img_std = img.std(axis=(-2, -1), keepdims=True)
-    img = np.divide(img, img_std, out=np.zeros_like(img), where=(img_std != 0))
-    if clip_norm:
-        return np.clip(img, 0, img.max())
-    else:
-        return img
+    for n in nb.prange(img.shape[0]):
+        img_ = img[n]
+        img_mean = np.float32(np.mean(img_))
+        img_ = img_ - img_mean
+        img_std = np.float32(np.std(img_))
+        if img_std != 0:
+            img_ = (img_ / img_std)
+        else:
+            img_ = np.zeros_like(img_, dtype=np.float32)
+        img[n] = img_
+    return img
+
+@nb.jit(nb.float32[:, :, :](nb.float32[:, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
+def normalize_intensity_clip(img: np.ndarray) -> np.ndarray:
+    """Normalize intensity of an image interrogation window using numba back-end and clip values to [0, max].
+
+    Parameters
+    ----------
+    img : np.ndarray (y, x)
+        Image window
+
+    Returns
+    -------
+    np.ndarray
+        (y, x) array with normalized intensities of window
+
+    """
+
+    for n in nb.prange(img.shape[0]):
+        img_ = img[n]
+        img_mean = np.float32(np.mean(img_))
+        img_ = img_ - img_mean
+        img_std = np.float32(np.std(img_))
+        if img_std != 0:
+            img_ = (img_ / img_std)
+        else:
+            img_ = np.zeros_like(img_, dtype=np.float32)
+        img[n] = np.clip(img_, 0, img_.max())
+    return img
+
+
+nb.jit(nb.float32[:, :, :, :](nb.float32[:, :, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
+def multi_normalize_intensity(imgs: np.ndarray) -> np.ndarray:
+    """Normalize intensities of several images in one go."""
+    for m in nb.prange(imgs.shape[0]):
+        imgs[m] = normalize_intensity(imgs[m])
+    return imgs
+
+nb.jit(nb.float32[:, :, :, :](nb.float32[:, :, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
+def multi_normalize_intensity_clip(imgs: np.ndarray) -> np.ndarray:
+    """Normalize intensities of several images in one go and clip values to [0, max]."""
+    for m in nb.prange(imgs.shape[0]):
+        imgs[m] = normalize_intensity_clip(imgs[m])
+    return imgs
 
 
 def rfft2(x):
@@ -48,18 +133,19 @@ def rfft2(x):
         Complex array containing the FFT result.
 
     """
-    return pyfftw.interfaces.numpy_fft.rfft2(x, threads=-1)
+    x_align = pyfftw.empty_aligned(x.shape, dtype=np.float32)
+    rfft = pyfftw.builders.rfft2(x_align, axes=(-2, -1), threads=multiprocessing.cpu_count(), planner_effort="FFTW_MEASURE")
+    rfft.input_array[:] = x
+    return rfft()
 
 
-def irfft2(x, s=None):
+def irfft2(x):
     """Compute 2D inverse real FFT using pyFFTW.
 
     Parameters
     ----------
     x : np.ndarray
         Input complex array.
-    s : tuple, optional
-        Shape of the output (optional).
 
     Returns
     -------
@@ -67,7 +153,12 @@ def irfft2(x, s=None):
         Real array containing the inverse FFT result.
 
     """
-    return pyfftw.interfaces.numpy_fft.irfft2(x, s=s, threads=-1)
+    x_align = pyfftw.empty_aligned(x.shape, dtype=np.complex64)
+    irfft = pyfftw.builders.irfft2(x_align, axes=(-2, -1), threads=multiprocessing.cpu_count(), planner_effort="FFTW_MEASURE")  # , s=s
+    irfft.input_array[:] = x
+    # return pyfftw.interfaces.dask_fft.irfft2(x, s=s)
+    return irfft()
+
 
 
 def fftshift(x, axes=None):
@@ -89,7 +180,64 @@ def fftshift(x, axes=None):
     return np.fft.fftshift(x, axes=axes)
 
 
-def ncc(image_a, image_b, clip_norm=False):
+# def ncc(image_a, image_b, clip_norm=False):
+#     """Perform normalized cross-correlation on a set of interrogation window pairs with pyFFTW back-end.
+#
+#     Parameters
+#     ----------
+#     image_a : np.ndarray
+#         float32 type array [w, y, x] containing a single image, sliced into interrogation windows (w)
+#     image_b : np.ndarray
+#         float32 type array [w, y, x] containing the next image, sliced into interrogation windows (w)
+#     clip_norm : bool, optional
+#         If set to True, the normalized intensities are clipped to the range [0, max] where max is the maximum of the
+#         window, before FFT is performed.
+#
+#     Returns
+#     -------
+#     np.ndarray
+#         float32 [w, y, x] correlations of interrogation window pixels
+#
+#     """
+#     const = np.float32(image_a.shape[-2] * image_a.shape[-1])
+#
+#     # Normalize images
+#     image_a = normalize_intensity(image_a, clip_norm)
+#     image_b = normalize_intensity(image_b, clip_norm)
+#
+#     # Get cached FFT objects or use interface
+#     shape = image_a.shape
+#     dtype_str = str(image_a.dtype)
+#
+#     # try:
+#     # Try to use cached FFTW objects for better performance
+#     input_a, output_a, fft_a, ifft_input, ifft_output, ifft_obj = _get_fft_objects(shape, dtype_str)
+#
+#     # Copy data to aligned arrays and compute FFT of image_a
+#     np.copyto(input_a, image_a)
+#     fft_a()
+#     f2a = np.conj(output_a.copy())
+#
+#     # Compute FFT of image_b
+#     np.copyto(input_a, image_b)
+#     fft_a()
+#     f2b = output_a.copy()
+#
+#     # Multiply and inverse FFT
+#     np.copyto(ifft_input, f2a * f2b)
+#     ifft_obj()
+#     corr = ifft_output.copy()
+#
+#     # except Exception:
+#     #     # Fallback to interface if cached objects fail
+#     #     f2a = np.conj(rfft2(image_a))
+#     #     f2b = rfft2(image_b)
+#     #     corr = irfft2(f2a * f2b)
+#
+#     return np.clip(fftshift(corr.real, axes=(-2, -1)) / const, 0, 1).astype(np.float32)
+
+
+def ncc(image_a, image_b, norm=True, clip_norm=False, rfft2_builder=None, irfft2_builder=None):
     """Perform normalized cross-correlation on a set of interrogation window pairs with pyFFTW back-end.
 
     Parameters
@@ -98,6 +246,10 @@ def ncc(image_a, image_b, clip_norm=False):
         uint8 type array [w, y, x] containing a single image, sliced into interrogation windows (w)
     image_b : np.ndarray
         uint8 type array [w, y, x] containing the next image, sliced into interrogation windows (w)
+    rfft2_builder : pyfftw builder object, optional
+        Pre-configured rfft2 builder for reuse. If None, creates a new one.
+    irfft2_builder : pyfftw builder object, optional
+        Pre-configured irfft2 builder for reuse. If None, creates a new one.
     clip_norm : bool, optional
         If set to True, the normalized intensities are clipped to the range [0, max] where max is the maximum of the
         window, before FFT is performed.
@@ -108,12 +260,33 @@ def ncc(image_a, image_b, clip_norm=False):
         float64 [w * y * x] correlations of interrogation window pixels
 
     """
+
     const = np.multiply(*image_a.shape[-2:])
-    image_a = normalize_intensity(image_a, clip_norm)
-    image_b = normalize_intensity(image_b, clip_norm)
-    f2a = np.conj(rfft2(image_a))
-    f2b = rfft2(image_b)
-    return np.clip(fftshift(irfft2(f2a * f2b).real, axes=(-2, -1)) / const, 0, 1)
+    if norm:
+        if clip_norm:
+            image_a = normalize_intensity_clip(image_a)
+            image_b = normalize_intensity_clip(image_b)
+        else:
+            image_a = normalize_intensity(image_a)
+            image_b = normalize_intensity(image_b)
+
+
+    if rfft2_builder is not None:
+        # Use pre-configured builders
+        rfft2_builder.input_array[:] = image_a
+        f2a = np.conj(rfft2_builder())
+
+        rfft2_builder.input_array[:] = image_b
+        f2b = rfft2_builder()
+
+        irfft2_builder.input_array[:] = f2a * f2b
+        corr = irfft2_builder()
+
+    else:
+        f2a = np.conj(rfft2(image_a))
+        f2b = rfft2(image_b)
+        corr = irfft2(f2a * f2b)
+    return np.clip(fftshift(corr.real, axes=(-2, -1)) / const, 0, 1)
 
 
 def multi_img_ncc(imgs, mask=None, idx=None, clip_norm=False):
@@ -138,18 +311,53 @@ def multi_img_ncc(imgs, mask=None, idx=None, clip_norm=False):
     Returns
     -------
     np.ndarray
-        float64 [(i - 1), w, y, x] correlations of interrogation window pixels for each image pair spanning i.
+        float32 [(i - 1), w, y, x] correlations of interrogation window pixels for each image pair spanning i.
 
     """
     corr = np.empty((len(imgs) - 1, imgs.shape[-3], imgs.shape[-2], imgs.shape[-1]), dtype=np.float32)
     corr.fill(np.nan)
     if idx is None:
         idx = np.repeat(True, imgs.shape[-3])
+    if clip_norm:
+        imgs = multi_normalize_intensity_clip(imgs[:, idx, :, :])
+    else:
+        imgs = multi_normalize_intensity(imgs[:, idx, :, :])
+
+
+    # Create aligned arrays and builders once, based on the indexed shape
+    n_windows = idx.sum()
+    window_shape = (n_windows, imgs.shape[-2], imgs.shape[-1])
+
+    # rfft2 input: real array, output: complex array with shape[-1] // 2 + 1
+    rfft2_input = pyfftw.empty_aligned(window_shape, dtype='float32')
+    rfft2_builder = pyfftw.builders.rfft2(
+        rfft2_input,
+        axes=(-2, -1),
+        threads=multiprocessing.cpu_count(),
+        planner_effort="FFTW_MEASURE",
+    )
+
+    # irfft2 input: complex array (output shape of rfft2), output: real array
+    irfft2_input_shape = (n_windows, imgs.shape[-2], imgs.shape[-1] // 2 + 1)
+    irfft2_input = pyfftw.empty_aligned(irfft2_input_shape, dtype='complex64')
+    irfft2_builder = pyfftw.builders.irfft2(
+        irfft2_input,
+        axes=(-2, -1),
+        threads=multiprocessing.cpu_count(),
+        planner_effort="FFTW_MEASURE",
+    )
+
     for n in range(len(imgs) - 1):
-        img_a = imgs[n, idx] * mask[idx]
-        img_b = imgs[n + 1, idx]
-        res = ncc(img_a, img_b, clip_norm)
-        corr[n, idx] = res.astype(np.float32)
+        img_a = imgs[n] * mask[idx]
+        img_b = imgs[n + 1]
+        res = ncc(
+            image_a=img_a,
+            image_b=img_b,
+            norm=False,
+            rfft2_builder=rfft2_builder,
+            irfft2_builder=irfft2_builder
+        )
+        corr[n, idx] = res
     return corr
 
 

--- a/ffpiv/pfftw.py
+++ b/ffpiv/pfftw.py
@@ -1,19 +1,21 @@
 """pyFFTW cross-correlation related functions."""
+
 import atexit
 import multiprocessing
-import numpy as np
-import numba as nb
 import os
 import pickle
+
+import numba as nb
+import numpy as np
 import pyfftw
 
 from ffpiv import _WISDOM_FILE
 
-
 # Configure pyFFTW for optimal performance
 pyfftw.interfaces.cache.enable()
 pyfftw.config.NUM_THREADS = multiprocessing.cpu_count()
-pyfftw.config.PLANNER_EFFORT = 'FFTW_MEASURE'
+pyfftw.config.PLANNER_EFFORT = "FFTW_MEASURE"
+
 
 def _load_wisdom():
     """Load FFTW wisdom from file if available."""
@@ -34,6 +36,7 @@ def _save_wisdom():
             pickle.dump(wisdom, f)
     except Exception:
         pass  # Silently ignore if we can't save wisdom
+
 
 _load_wisdom()
 
@@ -62,15 +65,16 @@ def normalize_intensity(img: np.ndarray) -> np.ndarray:
         img_ = img_ - img_mean
         img_std = np.float32(np.std(img_))
         if img_std != 0:
-            img_ = (img_ / img_std)
+            img_ = img_ / img_std
         else:
             img_ = np.zeros_like(img_, dtype=np.float32)
         img[n] = img_
     return img
 
+
 @nb.jit(nb.float32[:, :, :](nb.float32[:, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
 def normalize_intensity_clip(img: np.ndarray) -> np.ndarray:
-    """Normalize intensity of an image splitted in interrogation windows using numba back-end and clip values to [0, max].
+    """Normalize intensity and clip values to [0, max] image interrogation windows using numba back-end.
 
     Parameters
     ----------
@@ -83,14 +87,13 @@ def normalize_intensity_clip(img: np.ndarray) -> np.ndarray:
         (w, y, x) array with normalized intensities of all windows
 
     """
-
     for n in nb.prange(img.shape[0]):
         img_ = img[n]
         img_mean = np.float32(np.mean(img_))
         img_ = img_ - img_mean
         img_std = np.float32(np.std(img_))
         if img_std != 0:
-            img_ = (img_ / img_std)
+            img_ = img_ / img_std
         else:
             img_ = np.zeros_like(img_, dtype=np.float32)
         img[n] = np.clip(img_, 0, img_.max())
@@ -98,13 +101,18 @@ def normalize_intensity_clip(img: np.ndarray) -> np.ndarray:
 
 
 nb.jit(nb.float32[:, :, :, :](nb.float32[:, :, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
+
+
 def multi_normalize_intensity(imgs: np.ndarray) -> np.ndarray:
     """Normalize intensities of several images in one go using numba back-end."""
     for m in nb.prange(imgs.shape[0]):
         imgs[m] = normalize_intensity(imgs[m])
     return imgs
 
+
 nb.jit(nb.float32[:, :, :, :](nb.float32[:, :, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
+
+
 def multi_normalize_intensity_clip(imgs: np.ndarray) -> np.ndarray:
     """Normalize intensities of several images in one go and clip values to [0, max] using numba back-end."""
     for m in nb.prange(imgs.shape[0]):
@@ -127,7 +135,9 @@ def rfft2(x):
 
     """
     x_align = pyfftw.empty_aligned(x.shape, dtype=np.float32)
-    rfft = pyfftw.builders.rfft2(x_align, axes=(-2, -1), threads=multiprocessing.cpu_count(), planner_effort="FFTW_MEASURE")
+    rfft = pyfftw.builders.rfft2(
+        x_align, axes=(-2, -1), threads=multiprocessing.cpu_count(), planner_effort="FFTW_MEASURE"
+    )
     rfft.input_array[:] = x
     return rfft()
 
@@ -147,10 +157,11 @@ def irfft2(x):
 
     """
     x_align = pyfftw.empty_aligned(x.shape, dtype=np.complex64)
-    irfft = pyfftw.builders.irfft2(x_align, axes=(-2, -1), threads=multiprocessing.cpu_count(), planner_effort="FFTW_MEASURE")  # , s=s
+    irfft = pyfftw.builders.irfft2(
+        x_align, axes=(-2, -1), threads=multiprocessing.cpu_count(), planner_effort="FFTW_MEASURE"
+    )  # , s=s
     irfft.input_array[:] = x
     return irfft()
-
 
 
 def fftshift(x, axes=None):
@@ -172,7 +183,7 @@ def fftshift(x, axes=None):
     return pyfftw.interfaces.numpy_fft.fftshift(x, axes=axes)
 
 
-def _ncc(image_a, image_b, norm=True, clip_norm=False, rfft2_builder=None, f2a_buffer=None, irfft2_builder=None):
+def _ncc(image_a, image_b, norm=True, clip_norm=False, rfft2_builder=None, irfft2_builder=None):
     """Perform normalized cross-correlation on a set of interrogation window pairs with pyFFTW back-end.
 
     Parameters
@@ -181,15 +192,16 @@ def _ncc(image_a, image_b, norm=True, clip_norm=False, rfft2_builder=None, f2a_b
         uint8 type array [w, y, x] containing a single image, sliced into interrogation windows (w)
     image_b : np.ndarray
         uint8 type array [w, y, x] containing the next image, sliced into interrogation windows (w)
+    norm : bool, optional
+        If set, images will be normalized to have zero mean and 1 variance, if not, normalization should usually already
+        be performed outside of this function.
+    clip_norm : bool, optional
+        If set to True, the normalized intensities are clipped to the range [0, max] where max is the maximum of the
+        window, before FFT is performed.
     rfft2_builder : pyfftw builder object, optional
         Pre-configured rfft2 builder for reuse. If None, creates a new one.
     irfft2_builder : pyfftw builder object, optional
         Pre-configured irfft2 builder for reuse. If rfft2_builder is provided, this builder must also be provided.
-    f2a_buffer : np.ndarray, optional
-        Buffer aligned array to store intermediate calculations. Must be provided with builders.
-    clip_norm : bool, optional
-        If set to True, the normalized intensities are clipped to the range [0, max] where max is the maximum of the
-        window, before FFT is performed.
 
     Returns
     -------
@@ -197,30 +209,16 @@ def _ncc(image_a, image_b, norm=True, clip_norm=False, rfft2_builder=None, f2a_b
         float64 [w * y * x] correlations of interrogation window pixels
 
     """
-
     const = np.multiply(*image_a.shape[-2:])
-    # if norm:
-    #     if clip_norm:
-    #         image_a = normalize_intensity_clip(image_a)
-    #         image_b = normalize_intensity_clip(image_b)
-    #     else:
-    #         image_a = normalize_intensity(image_a)
-    #         image_b = normalize_intensity(image_b)
-
+    if norm:
+        if clip_norm:
+            image_a = normalize_intensity_clip(image_a)
+            image_b = normalize_intensity_clip(image_b)
+        else:
+            image_a = normalize_intensity(image_a)
+            image_b = normalize_intensity(image_b)
 
     if rfft2_builder is not None and irfft2_builder is not None:
-        # # Copy directly into aligned input buffer
-        # np.copyto(rfft2_builder.input_array[:], image_a)
-        # rfft2_builder.execute()
-        # np.conj(rfft2_builder.output_array[:], out=f2a_buffer)  # Store conjugate in-place
-        #
-        # np.copyto(rfft2_builder.input_array[:], image_b)
-        # rfft2_builder.execute()
-        #
-        # # Multiply and store in irfft input
-        # np.multiply(f2a_buffer[:], rfft2_builder.output_array[:], out=irfft2_builder.input_array[:])
-        # irfft2_builder.execute()
-        # corr = irfft2_builder.output_array[:]
         # Use pre-configured builders
         rfft2_builder.input_array[:] = image_a
         f2a = np.conj(rfft2_builder())
@@ -273,58 +271,40 @@ def multi_img_ncc(imgs, mask=None, idx=None, clip_norm=False):
     else:
         imgs = multi_normalize_intensity(imgs[:, idx, :, :])
 
-
     # Create aligned arrays and builders once, based on the indexed shape
     n_windows = idx.sum()
     window_shape = (n_windows, imgs.shape[-2], imgs.shape[-1])
     irfft2_input_shape = (n_windows, imgs.shape[-2], imgs.shape[-1] // 2 + 1)
 
     # rfft2 input: real array, output: complex array with shape[-1] // 2 + 1
-    rfft2_input = pyfftw.empty_aligned(window_shape, dtype='float32', n=pyfftw.simd_alignment)
-    # rfft2_output = pyfftw.empty_aligned(irfft2_input_shape, dtype='complex64', n=pyfftw.simd_alignment)
-    #
-    # Create FFTW objects with explicit input/output arrays
-    # rfft2_builder = pyfftw.FFTW(rfft2_input, rfft2_output, axes=(-2, -1),
-    #                         direction='FFTW_FORWARD', threads=os.cpu_count(),
-    #                         flags=('FFTW_MEASURE',))
-
+    rfft2_input = pyfftw.empty_aligned(window_shape, dtype="float32", n=pyfftw.simd_alignment)
     rfft2_builder = pyfftw.builders.rfft2(
         rfft2_input,
         axes=(-2, -1),
         threads=multiprocessing.cpu_count(),
         planner_effort="FFTW_MEASURE",
-        auto_align_input=False
+        auto_align_input=False,
     )
 
     # irfft2 input: complex array (output shape of rfft2), output: real array
-    irfft2_input = pyfftw.empty_aligned(irfft2_input_shape, dtype='complex64', n=pyfftw.simd_alignment)
-    # irfft2_output = pyfftw.empty_aligned(window_shape, dtype='float32', n=pyfftw.simd_alignment)
-
+    irfft2_input = pyfftw.empty_aligned(irfft2_input_shape, dtype="complex64", n=pyfftw.simd_alignment)
     irfft2_builder = pyfftw.builders.irfft2(
         irfft2_input,
         axes=(-2, -1),
         threads=multiprocessing.cpu_count(),
         planner_effort="FFTW_MEASURE",
-        auto_align_input=False
+        auto_align_input=False,
     )
-    # irfft2_builder = pyfftw.FFTW(irfft2_input, irfft2_output, axes=(-2, -1),
-    #                          direction='FFTW_BACKWARD', threads=os.cpu_count(),
-    #                          flags=('FFTW_MEASURE',))
-    #
     # Pre-allocate temporary arrays for intermediate results (also aligned)
-    f2a_buffer = pyfftw.empty_aligned(irfft2_input_shape, dtype='complex64', n=pyfftw.simd_alignment)
-
     for n in range(len(imgs) - 1):
         img_a = imgs[n] * mask[idx]
         img_b = imgs[n + 1]
         res = _ncc(
             image_a=img_a,
             image_b=img_b,
-            norm=True,
+            norm=False,
             rfft2_builder=rfft2_builder,
             irfft2_builder=irfft2_builder,
-            f2a_buffer=f2a_buffer
         )
         corr[n, idx] = res
     return corr
-

--- a/ffpiv/pfftw.py
+++ b/ffpiv/pfftw.py
@@ -8,15 +8,10 @@ import pickle
 import pyfftw
 
 from ffpiv import _WISDOM_FILE
-from functools import lru_cache
-
-# # # Enable FFTW caching for repeated transforms of the same size
-# pyfftw.interfaces.cache.enable()
 
 
 # Configure pyFFTW for optimal performance
 pyfftw.interfaces.cache.enable()
-# pyfftw.interfaces.cache.set_keepalive_time(30.0)  # Keep plans alive for 30 seconds
 pyfftw.config.NUM_THREADS = multiprocessing.cpu_count()
 pyfftw.config.PLANNER_EFFORT = 'FFTW_MEASURE'
 
@@ -27,7 +22,6 @@ def _load_wisdom():
             with open(_WISDOM_FILE, "rb") as f:
                 wisdom = pickle.load(f)
             pyfftw.import_wisdom(wisdom)
-            print("Loaded FFTW wisdom from file.")
         except Exception:
             pass  # Silently ignore if we can't load wisdom
 
@@ -38,7 +32,6 @@ def _save_wisdom():
         wisdom = pyfftw.export_wisdom()
         with open(_WISDOM_FILE, "wb") as f:
             pickle.dump(wisdom, f)
-        print("Saved FFTW wisdom to file.")
     except Exception:
         pass  # Silently ignore if we can't save wisdom
 
@@ -50,7 +43,7 @@ atexit.register(_save_wisdom)
 
 @nb.jit(nb.float32[:, :, :](nb.float32[:, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
 def normalize_intensity(img: np.ndarray) -> np.ndarray:
-    """Normalize intensity of an image interrogation window using numba back-end.
+    """Normalize intensity of an image splitted in interrogation windows using numba back-end.
 
     Parameters
     ----------
@@ -77,17 +70,17 @@ def normalize_intensity(img: np.ndarray) -> np.ndarray:
 
 @nb.jit(nb.float32[:, :, :](nb.float32[:, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
 def normalize_intensity_clip(img: np.ndarray) -> np.ndarray:
-    """Normalize intensity of an image interrogation window using numba back-end and clip values to [0, max].
+    """Normalize intensity of an image splitted in interrogation windows using numba back-end and clip values to [0, max].
 
     Parameters
     ----------
-    img : np.ndarray (y, x)
-        Image window
+    img : np.ndarray (w, y, x)
+        Image splitted in interrogation windows (w)
 
     Returns
     -------
     np.ndarray
-        (y, x) array with normalized intensities of window
+        (w, y, x) array with normalized intensities of all windows
 
     """
 
@@ -106,14 +99,14 @@ def normalize_intensity_clip(img: np.ndarray) -> np.ndarray:
 
 nb.jit(nb.float32[:, :, :, :](nb.float32[:, :, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
 def multi_normalize_intensity(imgs: np.ndarray) -> np.ndarray:
-    """Normalize intensities of several images in one go."""
+    """Normalize intensities of several images in one go using numba back-end."""
     for m in nb.prange(imgs.shape[0]):
         imgs[m] = normalize_intensity(imgs[m])
     return imgs
 
 nb.jit(nb.float32[:, :, :, :](nb.float32[:, :, :, :]), cache=True, nopython=True, parallel=True, nogil=True)
 def multi_normalize_intensity_clip(imgs: np.ndarray) -> np.ndarray:
-    """Normalize intensities of several images in one go and clip values to [0, max]."""
+    """Normalize intensities of several images in one go and clip values to [0, max] using numba back-end."""
     for m in nb.prange(imgs.shape[0]):
         imgs[m] = normalize_intensity_clip(imgs[m])
     return imgs
@@ -156,13 +149,12 @@ def irfft2(x):
     x_align = pyfftw.empty_aligned(x.shape, dtype=np.complex64)
     irfft = pyfftw.builders.irfft2(x_align, axes=(-2, -1), threads=multiprocessing.cpu_count(), planner_effort="FFTW_MEASURE")  # , s=s
     irfft.input_array[:] = x
-    # return pyfftw.interfaces.dask_fft.irfft2(x, s=s)
     return irfft()
 
 
 
 def fftshift(x, axes=None):
-    """Shift the zero-frequency component to the center.
+    """Shift the zero-frequency component to the center using pyfftw's numpy interfacing.
 
     Parameters
     ----------
@@ -177,67 +169,10 @@ def fftshift(x, axes=None):
         Shifted array.
 
     """
-    return np.fft.fftshift(x, axes=axes)
+    return pyfftw.interfaces.numpy_fft.fftshift(x, axes=axes)
 
 
-# def ncc(image_a, image_b, clip_norm=False):
-#     """Perform normalized cross-correlation on a set of interrogation window pairs with pyFFTW back-end.
-#
-#     Parameters
-#     ----------
-#     image_a : np.ndarray
-#         float32 type array [w, y, x] containing a single image, sliced into interrogation windows (w)
-#     image_b : np.ndarray
-#         float32 type array [w, y, x] containing the next image, sliced into interrogation windows (w)
-#     clip_norm : bool, optional
-#         If set to True, the normalized intensities are clipped to the range [0, max] where max is the maximum of the
-#         window, before FFT is performed.
-#
-#     Returns
-#     -------
-#     np.ndarray
-#         float32 [w, y, x] correlations of interrogation window pixels
-#
-#     """
-#     const = np.float32(image_a.shape[-2] * image_a.shape[-1])
-#
-#     # Normalize images
-#     image_a = normalize_intensity(image_a, clip_norm)
-#     image_b = normalize_intensity(image_b, clip_norm)
-#
-#     # Get cached FFT objects or use interface
-#     shape = image_a.shape
-#     dtype_str = str(image_a.dtype)
-#
-#     # try:
-#     # Try to use cached FFTW objects for better performance
-#     input_a, output_a, fft_a, ifft_input, ifft_output, ifft_obj = _get_fft_objects(shape, dtype_str)
-#
-#     # Copy data to aligned arrays and compute FFT of image_a
-#     np.copyto(input_a, image_a)
-#     fft_a()
-#     f2a = np.conj(output_a.copy())
-#
-#     # Compute FFT of image_b
-#     np.copyto(input_a, image_b)
-#     fft_a()
-#     f2b = output_a.copy()
-#
-#     # Multiply and inverse FFT
-#     np.copyto(ifft_input, f2a * f2b)
-#     ifft_obj()
-#     corr = ifft_output.copy()
-#
-#     # except Exception:
-#     #     # Fallback to interface if cached objects fail
-#     #     f2a = np.conj(rfft2(image_a))
-#     #     f2b = rfft2(image_b)
-#     #     corr = irfft2(f2a * f2b)
-#
-#     return np.clip(fftshift(corr.real, axes=(-2, -1)) / const, 0, 1).astype(np.float32)
-
-
-def ncc(image_a, image_b, norm=True, clip_norm=False, rfft2_builder=None, irfft2_builder=None):
+def _ncc(image_a, image_b, norm=True, clip_norm=False, rfft2_builder=None, f2a_buffer=None, irfft2_builder=None):
     """Perform normalized cross-correlation on a set of interrogation window pairs with pyFFTW back-end.
 
     Parameters
@@ -249,7 +184,9 @@ def ncc(image_a, image_b, norm=True, clip_norm=False, rfft2_builder=None, irfft2
     rfft2_builder : pyfftw builder object, optional
         Pre-configured rfft2 builder for reuse. If None, creates a new one.
     irfft2_builder : pyfftw builder object, optional
-        Pre-configured irfft2 builder for reuse. If None, creates a new one.
+        Pre-configured irfft2 builder for reuse. If rfft2_builder is provided, this builder must also be provided.
+    f2a_buffer : np.ndarray, optional
+        Buffer aligned array to store intermediate calculations. Must be provided with builders.
     clip_norm : bool, optional
         If set to True, the normalized intensities are clipped to the range [0, max] where max is the maximum of the
         window, before FFT is performed.
@@ -262,16 +199,28 @@ def ncc(image_a, image_b, norm=True, clip_norm=False, rfft2_builder=None, irfft2
     """
 
     const = np.multiply(*image_a.shape[-2:])
-    if norm:
-        if clip_norm:
-            image_a = normalize_intensity_clip(image_a)
-            image_b = normalize_intensity_clip(image_b)
-        else:
-            image_a = normalize_intensity(image_a)
-            image_b = normalize_intensity(image_b)
+    # if norm:
+    #     if clip_norm:
+    #         image_a = normalize_intensity_clip(image_a)
+    #         image_b = normalize_intensity_clip(image_b)
+    #     else:
+    #         image_a = normalize_intensity(image_a)
+    #         image_b = normalize_intensity(image_b)
 
 
-    if rfft2_builder is not None:
+    if rfft2_builder is not None and irfft2_builder is not None:
+        # # Copy directly into aligned input buffer
+        # np.copyto(rfft2_builder.input_array[:], image_a)
+        # rfft2_builder.execute()
+        # np.conj(rfft2_builder.output_array[:], out=f2a_buffer)  # Store conjugate in-place
+        #
+        # np.copyto(rfft2_builder.input_array[:], image_b)
+        # rfft2_builder.execute()
+        #
+        # # Multiply and store in irfft input
+        # np.multiply(f2a_buffer[:], rfft2_builder.output_array[:], out=irfft2_builder.input_array[:])
+        # irfft2_builder.execute()
+        # corr = irfft2_builder.output_array[:]
         # Use pre-configured builders
         rfft2_builder.input_array[:] = image_a
         f2a = np.conj(rfft2_builder())
@@ -318,6 +267,7 @@ def multi_img_ncc(imgs, mask=None, idx=None, clip_norm=False):
     corr.fill(np.nan)
     if idx is None:
         idx = np.repeat(True, imgs.shape[-3])
+    # imgs = imgs[:, idx, :, :]
     if clip_norm:
         imgs = multi_normalize_intensity_clip(imgs[:, idx, :, :])
     else:
@@ -327,193 +277,54 @@ def multi_img_ncc(imgs, mask=None, idx=None, clip_norm=False):
     # Create aligned arrays and builders once, based on the indexed shape
     n_windows = idx.sum()
     window_shape = (n_windows, imgs.shape[-2], imgs.shape[-1])
+    irfft2_input_shape = (n_windows, imgs.shape[-2], imgs.shape[-1] // 2 + 1)
 
     # rfft2 input: real array, output: complex array with shape[-1] // 2 + 1
-    rfft2_input = pyfftw.empty_aligned(window_shape, dtype='float32')
+    rfft2_input = pyfftw.empty_aligned(window_shape, dtype='float32', n=pyfftw.simd_alignment)
+    # rfft2_output = pyfftw.empty_aligned(irfft2_input_shape, dtype='complex64', n=pyfftw.simd_alignment)
+    #
+    # Create FFTW objects with explicit input/output arrays
+    # rfft2_builder = pyfftw.FFTW(rfft2_input, rfft2_output, axes=(-2, -1),
+    #                         direction='FFTW_FORWARD', threads=os.cpu_count(),
+    #                         flags=('FFTW_MEASURE',))
+
     rfft2_builder = pyfftw.builders.rfft2(
         rfft2_input,
         axes=(-2, -1),
         threads=multiprocessing.cpu_count(),
         planner_effort="FFTW_MEASURE",
+        auto_align_input=False
     )
 
     # irfft2 input: complex array (output shape of rfft2), output: real array
-    irfft2_input_shape = (n_windows, imgs.shape[-2], imgs.shape[-1] // 2 + 1)
-    irfft2_input = pyfftw.empty_aligned(irfft2_input_shape, dtype='complex64')
+    irfft2_input = pyfftw.empty_aligned(irfft2_input_shape, dtype='complex64', n=pyfftw.simd_alignment)
+    # irfft2_output = pyfftw.empty_aligned(window_shape, dtype='float32', n=pyfftw.simd_alignment)
+
     irfft2_builder = pyfftw.builders.irfft2(
         irfft2_input,
         axes=(-2, -1),
         threads=multiprocessing.cpu_count(),
         planner_effort="FFTW_MEASURE",
+        auto_align_input=False
     )
+    # irfft2_builder = pyfftw.FFTW(irfft2_input, irfft2_output, axes=(-2, -1),
+    #                          direction='FFTW_BACKWARD', threads=os.cpu_count(),
+    #                          flags=('FFTW_MEASURE',))
+    #
+    # Pre-allocate temporary arrays for intermediate results (also aligned)
+    f2a_buffer = pyfftw.empty_aligned(irfft2_input_shape, dtype='complex64', n=pyfftw.simd_alignment)
 
     for n in range(len(imgs) - 1):
         img_a = imgs[n] * mask[idx]
         img_b = imgs[n + 1]
-        res = ncc(
+        res = _ncc(
             image_a=img_a,
             image_b=img_b,
-            norm=False,
+            norm=True,
             rfft2_builder=rfft2_builder,
-            irfft2_builder=irfft2_builder
+            irfft2_builder=irfft2_builder,
+            f2a_buffer=f2a_buffer
         )
         corr[n, idx] = res
     return corr
 
-
-def peak_position(corr):
-    """Compute peak positions for correlations in each interrogation window using pyFFTW back-end.
-
-    Parameters
-    ----------
-    corr : np.ndarray
-        A 3D array of shape (w, y, x) representing the correlation maps for which the peak positions are to be
-        identified.
-
-    Returns
-    -------
-    subp_peak_position : np.ndarray
-        A 2D array of shape (w, 2) where each row corresponds to the subpixel peak positions (i, j) for each 2D slice
-        in the input correlation maps.
-
-    """
-    eps = 1e-7
-    # pre-define sub peak position array
-    subp_peak_position = np.zeros((len(corr), 2)) * np.nan
-    # Find argmax along axis (1, 2) for each 2D slice of the input
-    idx = np.argmax(corr.reshape(corr.shape[0], -1), axis=1)
-    peak1_i = idx // corr.shape[1]
-    peak1_j = idx % corr.shape[2]
-
-    # Adding eps to avoid log(0)
-    corr = corr + eps
-    valid_idx = np.where(
-        np.all(
-            np.array([peak1_i != 0, peak1_i != corr.shape[-2] - 1, peak1_j != 0, peak1_j != corr.shape[-1] - 1]), axis=0
-        )
-    )
-    peak1_i = peak1_i[valid_idx]
-    peak1_j = peak1_j[valid_idx]
-
-    # Indexing the peak and neighboring points for vectorized operations
-    c = corr[valid_idx, peak1_i, peak1_j] + eps
-    cl = corr[valid_idx, peak1_i - 1, peak1_j] + eps
-    cr = corr[valid_idx, peak1_i + 1, peak1_j] + eps
-    cd = corr[valid_idx, peak1_i, peak1_j - 1] + eps
-    cu = corr[valid_idx, peak1_i, peak1_j + 1] + eps
-
-    # Gaussian peak calculations (nom1, den1, nom2, den2)
-    nom1 = np.log(cl) - np.log(cr)
-    den1 = 2 * np.log(cl) - 4 * np.log(c) + 2 * np.log(cr) + eps
-    nom2 = np.log(cd) - np.log(cu)
-    den2 = 2 * np.log(cd) - 4 * np.log(c) + 2 * np.log(cu) + eps
-
-    # Subpixel peak position
-    subp_peak_position[valid_idx] = np.vstack([peak1_i + nom1 / den1, peak1_j + nom2 / den2]).T
-
-    return subp_peak_position
-
-
-def u_v_displacement(corr: np.ndarray, n_rows: int, n_cols: int):
-    """Compute u (x-direction) and v (y-direction) displacements from correlations using pyFFTW back end.
-
-    Results are organized following the row and column organization provided by `n_rows` and `n_cols`.
-
-    Parameters
-    ----------
-    corr : np.ndarray
-        A 3D array of shape [w, y, x] containing the correlation maps.
-    n_rows : int
-        Number of rows in the image interrogation windows.
-    n_cols : int
-        Number of columns in the image interrogation windows.
-
-    Returns
-    -------
-    u : np.ndarray
-        2D array containing x-direction displacements for each image pair and window.
-    v : np.ndarray
-        2D array containing y-direction displacements for each image pair and window.
-
-    """
-    peaks = peak_position(corr.astype(np.float64))
-    peaks_def = np.floor(np.array(corr[0, :, :].shape) / 2)
-    u = peaks[:, 1].reshape(n_rows, n_cols) - peaks_def[1]
-    v = peaks[:, 0].reshape(n_rows, n_cols) - peaks_def[0]
-    return u, v
-
-
-def multi_u_v_displacement(corr: np.ndarray, n_rows: int, n_cols: int):
-    """Compute u (x-direction) and v (y-direction) displacements for multiple correlation windows using pyFFTW back-end.
-
-    Parameters
-    ----------
-    corr : np.ndarray
-        A 4D array of shape [(i - 1), w, y, x] containing the correlation maps.
-    n_rows : int
-        Number of rows in the image interrogation windows.
-    n_cols : int
-        Number of columns in the image interrogation windows.
-
-    Returns
-    -------
-    u : np.ndarray
-        3D array containing x-direction displacements for each image pair and window.
-    v : np.ndarray
-        3D array containing y-direction displacements for each image pair and window.
-
-    """
-    u = np.empty((corr.shape[0], n_rows, n_cols))
-    v = np.empty((corr.shape[0], n_rows, n_cols))
-    for i in range(corr.shape[0]):
-        u[i], v[i] = u_v_displacement(corr[i], n_rows, n_cols)
-    return u, v
-
-
-
-def signal_to_noise(corr: np.ndarray) -> np.ndarray:
-    """Compute signal-to-noise ratio per interrogation window using pyFFTW back-end.
-
-    This is computed by dividing the peak of the correlation field by the mean.
-
-    Parameters
-    ----------
-    corr : np.ndarray
-        (w, y, x) correlations for each interrogation window (w).
-
-    Returns
-    -------
-    np.ndarray
-        vector with signal to noise ratios for each window.
-
-    """
-    s2n = np.empty(len(corr), dtype=np.float64)
-    for n in range(len(corr)):
-        _c = corr[n]
-        _c_max = _c.max()
-        if _c_max < 1e-3:
-            # no correlation
-            s2n[n] = 0.0
-        else:
-            s2n[n] = _c_max / abs(_c.mean())
-    return s2n
-
-
-def multi_signal_to_noise(corr: np.ndarray) -> np.ndarray:
-    """Compute signal to noise for multiple images at once using pyFFTW back-end.
-
-    Parameters
-    ----------
-    corr : np.ndarray
-        (i, w, y, x) correlations for each interrogation window (w) in each image pair (i).
-
-    Returns
-    -------
-    np.ndarray
-        (i, w) array with signal to noise ratios for each window and image pair.
-
-    """
-    s2n = np.zeros(corr.shape[0:2])
-    for i in range(len(corr)):
-        s2n[i] = signal_to_noise(corr[i])
-    return s2n

--- a/ffpiv/pnb.py
+++ b/ffpiv/pnb.py
@@ -3,6 +3,8 @@
 import numba as nb
 import numpy as np
 
+from ffpiv.nb_utils import u_v_displacement
+
 
 @nb.jit(cache=True, nopython=True)
 def rfft2(x):
@@ -35,7 +37,7 @@ def conj(x):
 
 
 @nb.jit(nb.float32[:, :](nb.float32[:, :]), cache=True, nopython=True)
-def normalize_intensity(img: np.ndarray) -> np.ndarray:
+def _normalize_intensity_window(img: np.ndarray) -> np.ndarray:
     """Normalize intensity of an image interrogation window using numba back-end.
 
     Parameters
@@ -59,7 +61,7 @@ def normalize_intensity(img: np.ndarray) -> np.ndarray:
     return img.astype(np.float32)
 
 @nb.jit(nb.float32[:, :](nb.float32[:, :]), cache=True, nopython=True)
-def normalize_intensity_clip(img: np.ndarray) -> np.ndarray:
+def _normalize_intensity_window_clip(img: np.ndarray) -> np.ndarray:
     """Normalize and clip (0, max value) intensity of an image interrogation window using numba back-end.
 
     Parameters
@@ -90,7 +92,7 @@ def normalize_intensity_clip(img: np.ndarray) -> np.ndarray:
     cache=True,
     nopython=True
 )
-def ncc(image_a, image_b, clip_norm):
+def _ncc(image_a, image_b, clip_norm):
     """Perform normalized cross correlation performed on a set of interrogation window pairs with numba back-end.
 
     Parameters
@@ -116,8 +118,8 @@ def ncc(image_a, image_b, clip_norm):
         for n in nb.prange(image_a.shape[0]):
             ima = image_a[n]
             imb = image_b[n]
-            ima = normalize_intensity_clip(ima)
-            imb = normalize_intensity_clip(imb)
+            ima = _normalize_intensity_window_clip(ima)
+            imb = _normalize_intensity_window_clip(imb)
             f2a = conj(rfft2(ima))
             f2b = rfft2(imb)
             corr = fftshift(irfft2(f2a * f2b).real, axes=(-2, -1))
@@ -126,8 +128,8 @@ def ncc(image_a, image_b, clip_norm):
         for n in nb.prange(image_a.shape[0]):
             ima = image_a[n]
             imb = image_b[n]
-            ima = normalize_intensity(ima)
-            imb = normalize_intensity(imb)
+            ima = _normalize_intensity_window(ima)
+            imb = _normalize_intensity_window(imb)
             f2a = conj(rfft2(ima))
             f2b = rfft2(imb)
             corr = fftshift(irfft2(f2a * f2b).real, axes=(-2, -1))
@@ -136,7 +138,7 @@ def ncc(image_a, image_b, clip_norm):
 
 
 @nb.jit(nogil=True, cache=True, nopython=True)
-def slice_a_b(imgs, n, mask, idx):
+def _slice_a_b(imgs, n, mask, idx):
     """Extract one frame as source and the next as destination for image velocimetry.
 
     This function masks non-relevant areas in the source image and removes windows that are not relevant.
@@ -190,88 +192,14 @@ def multi_img_ncc(imgs, mask, idx, clip_norm):
 
     """
     corr = np.empty(
-        (len(imgs) - 1, imgs.shape[-3], imgs.shape[-2], imgs.shape[-1]),
+        shape=(len(imgs) - 1, imgs.shape[-3], imgs.shape[-2], imgs.shape[-1]),
         dtype=nb.float32,
     )
     corr.fill(np.nan)
     for n in nb.prange(len(imgs) - 1):
-        img_a, img_b = slice_a_b(imgs, n, mask, idx)
-        corr[n, idx] = ncc(img_a, img_b, clip_norm).astype(nb.float32)
+        img_a, img_b = _slice_a_b(imgs, n, mask, idx)
+        corr[n, idx] = _ncc(img_a, img_b, clip_norm).astype(nb.float32)
     return corr
-
-
-@nb.jit(cache=True, nopython=True)
-def peak_position(corr):
-    """Compute peak positions for correlations in each interrogation window using numba back-end."""
-    eps = 1e-7
-    idx = np.argmax(corr)
-    peak1_i, peak1_j = idx // len(corr), idx % len(corr)
-    # check if valid
-    valid = peak1_i != 0 and peak1_i != corr.shape[-2] - 1 and peak1_j != 0 and peak1_j != corr.shape[-1] - 1
-    if valid:
-        corr = corr + eps  # prevents log(0) = nan if "gaussian" is used (notebook)
-        c = corr[peak1_i, peak1_j] + eps
-        cl = corr[peak1_i - 1, peak1_j] + eps
-        cr = corr[peak1_i + 1, peak1_j] + eps
-        cd = corr[peak1_i, peak1_j - 1] + eps
-        cu = corr[peak1_i, peak1_j + 1] + eps
-
-        # gaussian peak
-        nom1 = np.log(cl) - np.log(cr)
-        den1 = 2 * np.log(cl) - 4 * np.log(c) + 2 * np.log(cr) + eps
-        nom2 = np.log(cd) - np.log(cu)
-        den2 = 2 * np.log(cd) - 4 * np.log(c) + 2 * np.log(cu) + eps
-
-        subp_peak_position = np.array([peak1_i + nom1 / den1, peak1_j + nom2 / den2])
-    else:
-        subp_peak_position = np.array([np.nan, np.nan])
-    return subp_peak_position
-
-
-@nb.jit(parallel=True, cache=True, nopython=True)
-def u_v_displacement(
-    corr,
-    n_rows,
-    n_cols,
-):
-    """Compute u (x-direction) and v (y-direction) displacements.
-
-    u and v displacements are computed from correlations in windows and number and rows / columns using numba
-    back-end.
-
-    Parameters
-    ----------
-    corr : np.ndarray
-        (w, y, x) correlation planes for each interrogation window (w).
-    n_rows : int
-        number of rows in the correlation map.
-    n_cols : int
-        number of columns in the correlation map.
-
-    Returns
-    -------
-    u : np.ndarray
-        (n_rows, n_cols) array of x-direction velocimetry results in pixel displacements.
-    v : np.ndarray
-        (n_rows, n_cols) array of y-direction velocimetry results in pixel displacements.
-
-    """
-    u = np.zeros((n_rows, n_cols))
-    v = np.zeros((n_rows, n_cols))
-
-    # center point of the correlation map
-    default_peak_position = np.floor(np.array(corr[0, :, :].shape) / 2)
-    for k in nb.prange(n_rows):
-        for m in nb.prange(n_cols):
-            peak = (
-                peak_position(
-                    corr[k * n_cols + m],
-                )
-                - default_peak_position
-            )
-            u[k, m] = peak[1]
-            v[k, m] = peak[0]
-    return u, v
 
 
 @nb.jit(parallel=True, cache=True, nopython=True)

--- a/ffpiv/sample_data.py
+++ b/ffpiv/sample_data.py
@@ -14,7 +14,7 @@ def get_hommerich_dataset():
 
     # Define the DOI link
     filename = "hommerich_frames_20241010_081717.zip"
-    base_url = "doi:10.5281/zenodo.15002591"
+    base_url = "https://zenodo.org/records/15002591/files"
     url = base_url + "/" + filename
     print(f"Retrieving or providing cached version of dataset from {url}")
     # Create a Pooch registry to manage downloads

--- a/ffpiv/sample_data.py
+++ b/ffpiv/sample_data.py
@@ -14,7 +14,7 @@ def get_hommerich_dataset():
 
     # Define the DOI link
     filename = "hommerich_frames_20241010_081717.zip"
-    base_url = "doi:10.5281/zenodo.14161026"
+    base_url = "doi:10.5281/zenodo.15002591"
     url = base_url + "/" + filename
     print(f"Retrieving or providing cached version of dataset from {url}")
     # Create a Pooch registry to manage downloads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,14 @@ packages = [
 
 dependencies = [
     "numba",
-    "numpy>=1.23, <2",  # pin version to ensure compatibility with C-headers
+#    "numpy>=1.23, <2",  # pin version to ensure compatibility with C-headers
+    "numpy",  # pin version to ensure compatibility with C-headers
     "pillow",
     "pip",
+    "platformdirs",
     "psutil",
     "pyFFTW",
-    "rocket-fft; python_version <= '3.12'"
+    "rocket-fft; python_version <= '3.12'",
 ]
 
 requires-python =">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ extra = [
     "tqdm"
 ]
 test = [
-    "ffpiv[extra]",
+    "pooch",
+    "tqdm",
     "pytest",
     "pytest-cov",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "platformdirs",
     "psutil",
     "pyFFTW",
-    "rocket-fft; python_version <= '3.12'",
+    "rocket-fft; python_version <= '3.12'",  # has not been updated for a long time.
 ]
 
 requires-python =">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.4.0,<4"]
+requires = ["flit_core"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -13,7 +13,6 @@ packages = [
 
 dependencies = [
     "numba",
-#    "numpy>=1.23, <2",  # pin version to ensure compatibility with C-headers
     "numpy",  # pin version to ensure compatibility with C-headers
     "pillow",
     "pip",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = ['version', 'description']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "pillow",
     "pip",
     "psutil",
-    "rocket-fft"
+    "pyFFTW",
+    "rocket-fft; python_version <= '3.12'"
 ]
 
 requires-python =">=3.9"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,15 @@
+from typing import Literal
+
 import numpy as np
+import pytest
 
 from ffpiv import piv, piv_stack
 
 
-def test_piv_stack(imgs):
+@pytest.mark.parametrize("engine", ["numpy", "fftw", "numba"])
+def test_piv_stack(imgs: np.ndarray, engine: Literal["numpy", "fftw", "numba"]):
     """Test image stack result in one go."""
-    u, v = piv_stack(imgs, (64, 64), (32, 32), engine="fftw")
+    u, v = piv_stack(imgs, (64, 64), (32, 32), engine=engine)
 
     # Assertions to validate the outputs
     assert isinstance(u, np.ndarray), "Expected u to be a numpy array"
@@ -18,11 +22,12 @@ def test_piv_stack(imgs):
     assert v.shape[0] == len(imgs) - 1, "Expected the first dimension of v to match the number of images minus 1"
 
 
-def test_piv(imgs):
+@pytest.mark.parametrize("engine", ["numpy", "fftw", "numba"])
+def test_piv(imgs: np.ndarray, engine: Literal["numpy", "fftw", "numba"]):
     """Test single piv result for image pair."""
     img_a = imgs[0]
     img_b = imgs[1]
-    u, v = piv(img_a, img_b, window_size=(64, 64), overlap=(32, 16))
+    u, v = piv(img_a, img_b, window_size=(64, 64), overlap=(32, 16), engine=engine)
     assert isinstance(u, np.ndarray)
     assert isinstance(v, np.ndarray)
     assert u.shape == v.shape

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ from ffpiv import piv, piv_stack
 
 def test_piv_stack(imgs):
     """Test image stack result in one go."""
-    u, v = piv_stack(imgs, (64, 64), (32, 32))
+    u, v = piv_stack(imgs, (64, 64), (32, 32), engine="fftw")
 
     # Assertions to validate the outputs
     assert isinstance(u, np.ndarray), "Expected u to be a numpy array"

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -36,10 +36,15 @@ def correlations(img_pair):
     return corrs * np.random.rand(*corrs.shape) * 0.005
 
 
-@pytest.mark.parametrize("clip_norm", [False, True])
+@pytest.mark.parametrize("clip_norm", [False])
 def test_ncc(img_pair, clip_norm):
     """Test correlation analysis on a pair of image windows."""
     image_a, image_b = img_pair
+
+    img_1 = pfftw.normalize_intensity(image_a.astype(np.float32))
+    img_2 = pnp.normalize_intensity(image_a.astype(np.float32))
+    assert np.allclose(img_1, img_2)
+
     t1 = time.time()
     res_np = pnp.ncc(image_a, image_b, clip_norm)
     t2 = time.time()
@@ -53,7 +58,7 @@ def test_ncc(img_pair, clip_norm):
         print(f"Numba took {time_fftw} secs.")
         assert np.allclose(res_nb, res_np, atol=1e-6, rtol=1e-5)
     t1 = time.time()
-    res_fftw = pfftw.ncc(image_a, image_b, clip_norm)
+    res_fftw = pfftw.ncc(image_a, image_b, norm=True, clip_norm=False)
     t2 = time.time()
     time_nb = t2 - t1
     print(f"FFTW took {time_nb} secs.")

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -3,8 +3,12 @@ import time
 import numpy as np
 import pytest
 
-import ffpiv.pnb as pnb
+from ffpiv import HAS_ROCKET_FFT
+if HAS_ROCKET_FFT:
+    import ffpiv.pnb as pnb
+
 import ffpiv.pnp as pnp
+import ffpiv.pfftw as pfftw
 from ffpiv import window
 
 
@@ -28,7 +32,7 @@ def dims(imgs):
 
 @pytest.fixture()
 def correlations(img_pair):
-    corrs = pnb.ncc(*img_pair, clip_norm=False)
+    corrs = pfftw.ncc(*img_pair, clip_norm=False)
     return corrs * np.random.rand(*corrs.shape) * 0.005
 
 
@@ -37,46 +41,67 @@ def test_ncc(img_pair, clip_norm):
     """Test correlation analysis on a pair of image windows."""
     image_a, image_b = img_pair
     t1 = time.time()
-    res_nb = pnb.ncc(image_a, image_b, clip_norm)
-    t2 = time.time()
-    time_nb = t2 - t1
-    print(f"Numba took {time_nb} secs.")
-    t1 = time.time()
     res_np = pnp.ncc(image_a, image_b, clip_norm)
     t2 = time.time()
     time_np = t2 - t1
     print(f"Numpy took {time_np} secs.")
-    assert np.allclose(res_nb, res_np, atol=1e-6, rtol=1e-5)
+    if HAS_ROCKET_FFT:
+        t1 = time.time()
+        res_nb = pnb.ncc(image_a, image_b, clip_norm)
+        t2 = time.time()
+        time_fftw = t2 - t1
+        print(f"Numba took {time_fftw} secs.")
+        assert np.allclose(res_nb, res_np, atol=1e-6, rtol=1e-5)
+    t1 = time.time()
+    res_fftw = pfftw.ncc(image_a, image_b, clip_norm)
+    t2 = time.time()
+    time_nb = t2 - t1
+    print(f"FFTW took {time_nb} secs.")
+    assert np.allclose(res_fftw, res_np, atol=1e-6, rtol=1e-5)
 
 
 def test_multi_img_ncc(imgs_win_stack, mask):
     """Test cross correlation with several hundreds of images."""
     t1 = time.time()
-    idx = np.repeat(True, imgs_win_stack.shape[-3])
-    res_nb = pnb.multi_img_ncc(imgs_win_stack, mask, idx, clip_norm=False)
-    t2 = time.time()
-    time_nb = t2 - t1
-    print(f"Numba took {time_nb} secs.")
-    t1 = time.time()
     res_np = pnp.multi_img_ncc(imgs_win_stack, mask, clip_norm=False)
     t2 = time.time()
     time_nb = t2 - t1
     print(f"Numpy took {time_nb} secs.")
-    assert np.allclose(res_nb, res_np, atol=1e-6, rtol=1e-5)
+    if HAS_ROCKET_FFT:
+        t1 = time.time()
+        idx = np.repeat(True, imgs_win_stack.shape[-3])
+        res_nb = pnb.multi_img_ncc(imgs_win_stack, mask, idx, clip_norm=False)
+        t2 = time.time()
+        time_nb = t2 - t1
+        print(f"Numba took {time_nb} secs.")
+        assert np.allclose(res_nb, res_np, atol=1e-6, rtol=1e-5)
+    t1 = time.time()
+    res_fftw = pfftw.multi_img_ncc(imgs_win_stack, mask, clip_norm=False)
+    t2 = time.time()
+    time_fftw = t2 - t1
+    print(f"FFTW took {time_fftw} secs.")
+    assert np.allclose(res_fftw, res_np, atol=1e-6, rtol=1e-5)
 
 
 def test_u_v_displacement(correlations, dims):
     """Test displacement functionalities."""
+    if HAS_ROCKET_FFT:
+        n_rows, n_cols = dims
+        t1 = time.time()
+        _ = pnb.u_v_displacement(correlations, n_rows, n_cols)
+        t2 = time.time()
+        print(f"Peak position search took {t2 - t1} seconds")
+
     n_rows, n_cols = dims
     t1 = time.time()
-    _ = pnb.u_v_displacement(correlations, n_rows, n_cols)
+    _ = pfftw.u_v_displacement(correlations, n_rows, n_cols)
     t2 = time.time()
-    print(f"Peak position search took {t2 - t1} seconds")
+    print(f"Peak position search with FFTW took {t2 - t1} seconds")
 
     t1 = time.time()
     _ = pnp.u_v_displacement(correlations, n_rows, n_cols)
     t2 = time.time()
-    print(f"Peak position search with OpenPIV took {t2 - t1} seconds")
+    print(f"Peak position search with numpy took {t2 - t1} seconds")
 
     # plt.quiver(u2, v2, color="r", alpha=0.5)
     # plt.quiver(u, v, color="b", alpha=0.5)
@@ -90,8 +115,13 @@ def test_peaks_numpy(correlations):
 
 def test_signal_to_noise(correlations):
     # compile
-    _ = pnb.signal_to_noise(correlations)
+    if HAS_ROCKET_FFT:
+        _ = pnb.signal_to_noise(correlations)
+        t1 = time.time()
+        _ = pnb.signal_to_noise(correlations)
+        t2 = time.time()
+        print(f"Signal to noise calculation using Numba took {t2 - t1} seconds")
     t1 = time.time()
-    _ = pnb.signal_to_noise(correlations)
+    _ = pfftw.signal_to_noise(correlations)
     t2 = time.time()
-    print(f"Signal to noise calculation took {t2 - t1} seconds")
+    print(f"Signal to noise calculation using FFTW took {t2 - t1} seconds")

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -3,12 +3,14 @@ import time
 import numpy as np
 import pytest
 
+import ffpiv.nb_utils
 from ffpiv import HAS_ROCKET_FFT
+
 if HAS_ROCKET_FFT:
     import ffpiv.pnb as pnb
 
-import ffpiv.pnp as pnp
 import ffpiv.pfftw as pfftw
+import ffpiv.pnp as pnp
 from ffpiv import window
 
 
@@ -32,7 +34,7 @@ def dims(imgs):
 
 @pytest.fixture()
 def correlations(img_pair):
-    corrs = pfftw.ncc(*img_pair, clip_norm=False)
+    corrs = pfftw._ncc(*img_pair, clip_norm=False)
     return corrs * np.random.rand(*corrs.shape) * 0.005
 
 
@@ -52,13 +54,13 @@ def test_ncc(img_pair, clip_norm):
     print(f"Numpy took {time_np} secs.")
     if HAS_ROCKET_FFT:
         t1 = time.time()
-        res_nb = pnb.ncc(image_a, image_b, clip_norm)
+        res_nb = pnb._ncc(image_a, image_b, clip_norm)
         t2 = time.time()
         time_fftw = t2 - t1
         print(f"Numba took {time_fftw} secs.")
         assert np.allclose(res_nb, res_np, atol=1e-6, rtol=1e-5)
     t1 = time.time()
-    res_fftw = pfftw.ncc(image_a, image_b, norm=True, clip_norm=False)
+    res_fftw = pfftw._ncc(image_a, image_b, norm=True, clip_norm=False)
     t2 = time.time()
     time_nb = t2 - t1
     print(f"FFTW took {time_nb} secs.")
@@ -93,16 +95,11 @@ def test_u_v_displacement(correlations, dims):
     if HAS_ROCKET_FFT:
         n_rows, n_cols = dims
         t1 = time.time()
-        _ = pnb.u_v_displacement(correlations, n_rows, n_cols)
+        _ = ffpiv.nb_utils.u_v_displacement(correlations, n_rows, n_cols)
         t2 = time.time()
-        print(f"Peak position search took {t2 - t1} seconds")
+        print(f"Peak position search with numba took {t2 - t1} seconds")
 
     n_rows, n_cols = dims
-    t1 = time.time()
-    _ = pfftw.u_v_displacement(correlations, n_rows, n_cols)
-    t2 = time.time()
-    print(f"Peak position search with FFTW took {t2 - t1} seconds")
-
     t1 = time.time()
     _ = pnp.u_v_displacement(correlations, n_rows, n_cols)
     t2 = time.time()
@@ -118,6 +115,7 @@ def test_peaks_numpy(correlations):
     print(peaks)
 
 
+@pytest.mark.skipif(not HAS_ROCKET_FFT, reason="Rocket-FFT not available, skipping signal to noise test.")
 def test_signal_to_noise(correlations):
     # compile
     if HAS_ROCKET_FFT:
@@ -126,7 +124,3 @@ def test_signal_to_noise(correlations):
         _ = pnb.signal_to_noise(correlations)
         t2 = time.time()
         print(f"Signal to noise calculation using Numba took {t2 - t1} seconds")
-    t1 = time.time()
-    _ = pfftw.signal_to_noise(correlations)
-    t2 = time.time()
-    print(f"Signal to noise calculation using FFTW took {t2 - t1} seconds")


### PR DESCRIPTION
- Added pyFFTW compatibility with new `engine="fftw"` option.
- Changed install script to exclude `rocket-fft` in case `python > 3.12`. This is because `rocket-fft` is not yet available under `python > 3.12`.
