### PR TITLE
30 pre filter interrogation windows with low signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# PyFFTW compiled files
+piv_fftw*
+
+# VS Code
+.vscode
+
 # pycharm
 .idea
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## [0.2.1] - 2026-XX-XX
+## [0.2.1] - 2026-05-21
 ### Added
-- optional filtering of image windows with too little measured intensities. Only windows above a threshold between 0-1
-  are kept. Default value is `None` meaning no thresholding is applied and results are the same as previous versions.
+- optional filtering of image windows with too little measured intensities > 0. Only windows above a threshold between
+  0-1 are kept. Default value is `None` meaning no thresholding is applied and results are the same as previous
+  versions. README is extended to show this functionality using the `signal_threshold` parameter.
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.2.1] - 2026-XX-XX
+### Added
+- optional filtering of image windows with too little measured intensities. Only windows above a threshold between 0-1
+  are kept. Default value is `None` meaning no thresholding is applied and results are the same as previous versions.
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+
 ## [0.2.0] - 2025-12-22
 ### Added
 - New engine `engine="fftw"` for FFT-based processing. This engine is faster than the default engine `engine="numpy"`

--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ You may want to further analyze the correlation, or retrieve velocity by first a
 retrieving velocities instead of vice versa. To this end, you can also retrieve the cross-correlations
 themselves.
 
+> [!NOTE]
+> If your input frames contain many zeros (e.g. if you first apply differences in time
+> with thresholding to zero), then you can also leave out computations for areas with many zeros. This speeds up
+> calculations for preprocessed videos with many zeros, and can significantly reduce noise. Check the commented code
+> around the line that calls `cross_corr` for an example.
+
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
@@ -280,6 +286,13 @@ image_stack = np.stack([np.array(Image.open(file)) for file in files[:last_image
 
 # retrieve the cross correlation analysis with the x and y axis of the eventual data
 x, y, corr = cross_corr(image_stack, window_size=window_size, overlap=overlap)
+
+# NOTE: if you want to only perform cross correlation on images that have at least a certain fraction intensities
+# above zero (e.g. applicable on normalized and thresholded images, or differences in time) you may use an
+# additional parameter `signal_threshold` between 0-1 to indicate how many. Comment the line above and uncomment the
+# line below to compute cross correlations only with interrogation windows having at least 20% intensities larger than
+# zero.
+# x, y, corr = cross_corr(image_stack, window_size=window_size, overlap=overlap, signal_threshold=0.2)
 
 # perhaps we want to know what the highest correlation is per interrogation window and per image
 corr_max = np.nanmax(corr, axis=(-1, -2))  # dimension 0 is the image dimension, 1 is the interrogation window dimension

--- a/ffpiv/__init__.py
+++ b/ffpiv/__init__.py
@@ -1,6 +1,6 @@
 """FF-PIV: Fast and Flexible Particle Image Velocimetry analysis powered by numba."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from pathlib import Path
 

--- a/ffpiv/api.py
+++ b/ffpiv/api.py
@@ -142,7 +142,7 @@ def piv(
         overlap=overlap,
         engine=engine,
         normalize=normalize,
-        signal_score_threshold=signal_score_threshold,
+        signal_threshold=signal_score_threshold,
         clip_norm=clip_norm,
     )
     # get displacements
@@ -204,7 +204,7 @@ def cross_corr(
     overlap: Tuple[int, int] = (32, 32),
     search_area_size: Optional[Tuple[int, int]] = None,
     engine: Literal["fftw", "numba", "numpy"] = "fftw",
-    signal_score_threshold: Optional[float] = None,
+    signal_threshold: Optional[float] = None,
     normalize: bool = False,
     clip_norm: bool = False,
     verbose: bool = True,
@@ -225,7 +225,7 @@ def cross_corr(
     engine : Literal["fftw", "numba", "numpy"], optional
         The engine to use for calculation, by default "fftw".
         "numba" only works for python <= 3.12 as it depends on rocket_fft, which is unsupported on later versions.
-    signal_score_threshold : float, optional
+    signal_threshold : float, optional
         The threshold for the signal score, which is the fraction of non-zero pixels in the window stack. Windows
         with a signal score below this threshold will be set to NaN in the correlation array
     normalize : bool, optional
@@ -305,13 +305,13 @@ def cross_corr(
     else:
         corr = pnb.multi_img_ncc(window_stack, mask=mask, idx=idx, clip_norm=clip_norm)
     # remove windows with too little signal
-    if signal_score_threshold is not None and signal_score_threshold > 0:
+    if signal_threshold is not None and signal_threshold > 0:
         signal_score = np.count_nonzero(
             window_stack.reshape(window_stack.shape[0], window_stack.shape[1], -1), -1
         ) / np.prod(window_size)
         # if one of the frames has too little signal, the correlation is set to NaN
         signal_score = np.minimum(signal_score[0:-1], signal_score[1:])
-        corr[signal_score < signal_score_threshold] = np.nan
+        corr[signal_score < signal_threshold] = np.nan
     # memory cleanup
     del idx, mask, window_stack
     gc.collect()

--- a/ffpiv/api.py
+++ b/ffpiv/api.py
@@ -7,12 +7,13 @@ from typing import Literal, Optional, Tuple
 
 import numpy as np
 
-from ffpiv import window, HAS_ROCKET_FFT
+from ffpiv import HAS_ROCKET_FFT, window
 
 if HAS_ROCKET_FFT:
     import ffpiv.pnb as pnb
 import ffpiv.pfftw as pfftw
 import ffpiv.pnp as pnp
+
 
 def check_engine(engine: Literal["fftw", "numba", "numpy"] = "fftw"):
     """Check if the requested engine is available.
@@ -95,6 +96,8 @@ def piv(
     window_size: Tuple[int, int] = (64, 64),
     overlap: Tuple[int, int] = (0, 0),
     engine: Literal["numba", "numpy", "fftw"] = "fftw",
+    signal_score_threshold: Optional[float] = None,
+    normalize: bool = False,
     clip_norm: bool = False,
 ):
     """Perform particle image velocimetry on a pair of images.
@@ -112,6 +115,10 @@ def piv(
     engine : Literal["fftw", "numba", "numpy"], optional
         Compute correlations and displacements with "fftw" (default) or "numpy" or "numba"
         "numba" only works for python <= 3.12 as it depends on rocket_fft, which is unsupported on later versions.
+    signal_score_threshold : float, optional
+        Threshold for signal score to filter out low-signal windows.
+    normalize : bool, optional
+        If set to True, the window intensities are normalized before FFT is performed.
     clip_norm : bool, optional
         If set to True, the normalized intensities is clipped to the range [0, max] where max is the maximum of the
         window, before FFT is performed.
@@ -129,7 +136,15 @@ def piv(
     # get subwindows
     imgs = np.stack((img_a, img_b), axis=0).astype(np.float64)
     # get correlations and row/column layout
-    x, y, corr = cross_corr(imgs, window_size=window_size, overlap=overlap, engine=engine, clip_norm=clip_norm)
+    x, y, corr = cross_corr(
+        imgs,
+        window_size=window_size,
+        overlap=overlap,
+        engine=engine,
+        normalize=normalize,
+        signal_score_threshold=signal_score_threshold,
+        clip_norm=clip_norm,
+    )
     # get displacements
     n_rows, n_cols = len(y), len(x)
     u, v = u_v_displacement(corr, n_rows, n_cols)
@@ -189,6 +204,7 @@ def cross_corr(
     overlap: Tuple[int, int] = (32, 32),
     search_area_size: Optional[Tuple[int, int]] = None,
     engine: Literal["fftw", "numba", "numpy"] = "fftw",
+    signal_score_threshold: Optional[float] = None,
     normalize: bool = False,
     clip_norm: bool = False,
     verbose: bool = True,
@@ -209,6 +225,9 @@ def cross_corr(
     engine : Literal["fftw", "numba", "numpy"], optional
         The engine to use for calculation, by default "fftw".
         "numba" only works for python <= 3.12 as it depends on rocket_fft, which is unsupported on later versions.
+    signal_score_threshold : float, optional
+        The threshold for the signal score, which is the fraction of non-zero pixels in the window stack. Windows
+        with a signal score below this threshold will be set to NaN in the correlation array
     normalize : bool, optional
         if set, each window will be normalized with spatial mean and standard deviation, and numbers capped to 0.
     clip_norm : bool, optional
@@ -268,6 +287,7 @@ def cross_corr(
         search_area_size=search_area_size,
         overlap=overlap,
     )
+
     # normalization
     if normalize:
         window_stack = window.normalize(window_stack, mode="xy")
@@ -284,6 +304,14 @@ def cross_corr(
         corr = pfftw.multi_img_ncc(window_stack, mask=mask, idx=idx, clip_norm=clip_norm)
     else:
         corr = pnb.multi_img_ncc(window_stack, mask=mask, idx=idx, clip_norm=clip_norm)
+    # remove windows with too little signal
+    if signal_score_threshold is not None and signal_score_threshold > 0:
+        signal_score = np.count_nonzero(
+            window_stack.reshape(window_stack.shape[0], window_stack.shape[1], -1), -1
+        ) / np.prod(window_size)
+        # if one of the frames has too little signal, the correlation is set to NaN
+        signal_score = np.minimum(signal_score[0:-1], signal_score[1:])
+        corr[signal_score < signal_score_threshold] = np.nan
     # memory cleanup
     del idx, mask, window_stack
     gc.collect()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,11 @@ def test_piv_stack(imgs: np.ndarray, engine: Literal["numpy", "fftw", "numba"]):
 
 
 @pytest.mark.parametrize("engine", ["numpy", "fftw", "numba"])
-def test_piv(imgs: np.ndarray, engine: Literal["numpy", "fftw", "numba"]):
+@pytest.mark.parametrize("normalize", [False, True])  # Test the first three pairs of images
+@pytest.mark.parametrize("signal_score_threshold", [None, 0.2])  # Test the first three pairs of images
+def test_piv(
+    imgs: np.ndarray, engine: Literal["numpy", "fftw", "numba"], normalize: bool, signal_score_threshold: float
+):
     """Test single piv result for image pair."""
     img_a = imgs[0]
     img_b = imgs[1]


### PR DESCRIPTION
Added a pre filter for interrogation windows with too little signal. Fixed with a new optional parameter `signal_threshold` in `api.cross_corr`.
fixes #30